### PR TITLE
167 e2e and application page routing updates

### DIFF
--- a/frontend/e2e/app.po.ts
+++ b/frontend/e2e/app.po.ts
@@ -91,7 +91,7 @@ export class ChristmasTreeForm {
       const url = currentUrl;
       browser.get(url);
       expect<any>(browser.getCurrentUrl()).toContain(
-        `http://localhost:4200/applications/christmas-trees/forests/${forest}/new/`
+        `http://localhost:4200/applications/christmas-trees/forests/${forest}/new`
       );
     });
   }
@@ -149,16 +149,6 @@ export class ChristmasTreeFormAfterCancel {
 
   mockPayGovSubmit() {
     return element(by.id('mock-pay-gov-submit'));
-  }
-
-  refreshAndReturnToForm(forest) {
-    return browser.getCurrentUrl().then(function(currentUrl) {
-      const url = currentUrl;
-      browser.get(url);
-      expect<any>(browser.getCurrentUrl()).toContain(
-        `http://localhost:4200/applications/christmas-trees/forests/${forest}/new`
-      );
-    });
   }
 }
 

--- a/frontend/e2e/app.po.ts
+++ b/frontend/e2e/app.po.ts
@@ -91,6 +91,71 @@ export class ChristmasTreeForm {
       const url = currentUrl;
       browser.get(url);
       expect<any>(browser.getCurrentUrl()).toContain(
+        `http://localhost:4200/applications/christmas-trees/forests/${forest}/new/`
+      );
+    });
+  }
+}
+
+export class ChristmasTreeFormAfterCancel {
+  navigateTo(forestId, paygovToken) {
+    return browser.get(`applications/christmas-trees/forests/${forestId}/new/${paygovToken}`);
+  }
+  firstName() {
+    return element(by.css('input[id$="primary-permit-holder-first-name"]'));
+  }
+  firstNameError() {
+    return element(by.css('span[id$="primary-permit-holder-first-name-error"]'));
+  }
+  lastName() {
+    return element(by.css('input[id$="primary-permit-holder-last-name"]'));
+  }
+  lastNameError() {
+    return element(by.css('span[id$="primary-permit-holder-last-name-error"]'));
+  }
+
+  email() {
+    return element(by.css('input[id$="email"]'));
+  }
+  emailError() {
+    return element(by.css('span[id$="email-error"]'));
+  }
+
+  treeAmount() {
+    return element(by.css('input[id$="quantity"]'));
+  }
+  treeAmountError() {
+    return element(by.css('span[id$="quantity-error"]'));
+  }
+
+  permitCost() {
+    return element(by.css('span[id$="total-cost"]'));
+  }
+
+  rulesAccepted() {
+    return element(by.id('accept-rules-label'));
+  }
+  rulesAcceptedError() {
+    return element(by.css('span[id$="accept-rules-error"]'));
+  }
+
+  cancelInfo() {
+    return element(by.css('.usa-alert-info'));
+  }
+
+  submit() {
+    return element(by.id('submit-application'));
+  }
+
+  mockPayGovSubmit() {
+    return element(by.id('mock-pay-gov-submit'));
+  }
+
+  refreshAndReturnToForm(forest) {
+    return browser.getCurrentUrl().then(function(currentUrl) {
+      const url = currentUrl;
+      browser.get(url);
+      expect<any>(browser.getCurrentUrl()).toContain(
         `http://localhost:4200/applications/christmas-trees/forests/${forest}/new`
       );
     });

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -117,7 +117,7 @@ const appRoutes: Routes = [
     }
   },
   {
-    path: 'applications/christmas-trees/forests/:id/new/:permitId',
+    path: 'applications/christmas-trees/forests/:id/new/:paygovId',
     component: TreeApplicationFormComponent,
     resolve: {
       forest: ForestResolver,

--- a/frontend/src/app/application-forms/tree-application-form/christmas-tree-permit-detail-resolver.service.ts
+++ b/frontend/src/app/application-forms/tree-application-form/christmas-tree-permit-detail-resolver.service.ts
@@ -11,7 +11,7 @@ export class ChristmasTreePermitDetailResolver implements Resolve<any> {
   constructor(private service: ChristmasTreesApplicationService, private router: Router) {}
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> {
-    const id = route.paramMap.get('permitId');
+    const id = route.paramMap.get('paygovId');
     const forest = route.paramMap.get('id');
 
     return this.service

--- a/server/src/controllers/christmas-tree.es6
+++ b/server/src/controllers/christmas-tree.es6
@@ -328,7 +328,7 @@ christmasTree.getOnePermitDetail = (req, res) => {
   treesDb.christmasTreesPermits
     .findOne({
       where: {
-        permitId: req.params.id
+        paygov_token: req.params.id
       }
     })
     .then(permit => {

--- a/server/src/mocks/pay-gov-mocks.es6
+++ b/server/src/mocks/pay-gov-mocks.es6
@@ -112,7 +112,7 @@ payGov.router.get('/mock-pay-gov', middleware.setCorsHeaders, function(req, res)
           '/applications/christmas-trees/forests/' +
           permit.christmasTreesForest.forestAbbr +
           '/new/' +
-          permit.permitId;
+          permit.paygovToken;
         const mockResponse = {
           token: permit.permitId,
           paymentAmount: permit.totalCost,


### PR DESCRIPTION
Updated routing on frontend to use paygov_token instead of permit_id to enable e2e tests
Updated cancelURL from backend to use paygov_token
Added e2e specs for application page after cancel button clicked