### PR TITLE
add dropshadow to menu button

### DIFF
--- a/frontend/src/app/trees/forests/tree-guidelines/tree-buy-permit-bar/buy-permit-bar.component.ts
+++ b/frontend/src/app/trees/forests/tree-guidelines/tree-buy-permit-bar/buy-permit-bar.component.ts
@@ -24,7 +24,13 @@ export class BuyPermitBarComponent {
     if (this.forest.isSeasonOpen) {
       const buyPermitLinkPosition = this.doc.getElementById('static-buy-permit-link').getBoundingClientRect().top;
       // use -20 instead of 0 so user scrolls slightly past this button before the pay button bar appears
-      this.top = (buyPermitLinkPosition < -20) ? '0px' : '-100px';
+      if (buyPermitLinkPosition < -20) {
+        this.top = '0px';
+        document.getElementById('mobile-menu-btn').classList.add('shadow');
+      } else {
+        this.top = '-100px';
+        document.getElementById('mobile-menu-btn').classList.remove('shadow');
+      }
     }
   }
 }

--- a/frontend/src/sass/elements/_sidebar.scss
+++ b/frontend/src/sass/elements/_sidebar.scss
@@ -1,4 +1,5 @@
 .mobile-menu-btn {
+  box-shadow: 0px 4px 20px $dark-grey;
   position: absolute;
   top: 162px;
   right: 0;

--- a/frontend/src/sass/elements/_sidebar.scss
+++ b/frontend/src/sass/elements/_sidebar.scss
@@ -1,9 +1,11 @@
 .mobile-menu-btn {
-  box-shadow: 0px 4px 20px $dark-grey;
   position: absolute;
   top: 162px;
   right: 0;
   z-index: 999;
+  &.shadow {
+    box-shadow: 0px 4px 20px $dark-grey;
+  }
   @media (min-width: $small-screen) {
     top: 140px;
   }

--- a/frontend/src/sass/elements/_sticky-bar.scss
+++ b/frontend/src/sass/elements/_sticky-bar.scss
@@ -21,15 +21,13 @@
   }
   &.top {
     top: 0;
-    @media (min-width: $nav-width) {
-      box-shadow: 0px 10px 20px $dark-grey;
-    }
+    box-shadow: 0px 4px 20px $dark-grey;
   }
   &.bottom {
     left: 0;
     padding: 0;
     bottom: 0;
-    box-shadow: 0px -10px 20px $dark-grey;
+    box-shadow: 0px -4px 20px $dark-grey;
   }
 
   h3 {

--- a/frontend/src/sass/elements/_sticky-bar.scss
+++ b/frontend/src/sass/elements/_sticky-bar.scss
@@ -35,19 +35,18 @@
     margin-top: 0;
   }
 
+  button {
+    margin-left: 2rem;
+    @media (max-width: $medium-screen) {
+      width: 100%;
+      margin-left: 0;
+    }
+  }
+
   #sticky-bar-forestname {
     display: none;
     @media (min-width: $nav-width) {
         display: inline-block;
-    }
-  }
-
-  @media (max-width: $medium-screen) {
-    button {
-      width: 100%;
-    }
-    #sticky-bar-desc-container {
-      display: none;
     }
   }
 
@@ -58,6 +57,9 @@
   #sticky-bar-desc-container {
     span {
       padding: 2rem;
+    }
+    @media (max-width: $medium-screen) {
+      display: none;
     }
   }
 

--- a/frontend/src/sass/elements/_sticky-bar.scss
+++ b/frontend/src/sass/elements/_sticky-bar.scss
@@ -62,8 +62,6 @@
       display: none;
     }
   }
-
-
 }
 
 .sticky-bar-label {


### PR DESCRIPTION
Conditionally add drop-shadow to menu button to match the sticky header on mobile.
<img width="676" alt="screen shot 2018-04-05 at 9 49 51 am" src="https://user-images.githubusercontent.com/2347759/38373642-52b6d8f8-38b7-11e8-8b6a-d281504e06ae.png">
<img width="887" alt="screen shot 2018-04-05 at 10 22 40 am" src="https://user-images.githubusercontent.com/2347759/38375223-4d7e4782-38bb-11e8-963e-b01b7c2333d4.png">

